### PR TITLE
Merge sfrinaldi/add-ci-check into develop

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,12 @@ _List any issues this Pull Request relates too in order to tie issues with Pull 
 ## Testing Performed
 _List any related testing that was preformed or direct to an issue that has this information. Remove this section as needed._
 
+### ETC Branch
+_Indicate what branch the pipeline checks should be using for running tests against (if applicable)._
+
+> [!Note]
+> You will have to request someone to change the variable for this repository to the correct branch that you indicated above for the pipeline to run accordingly! (Defaults to main branch for the corresponding ETC repo)
+
 ---------------------
 
 **NOTE:** Refer to the [UASAL Development Guide](https://teledocs.space/docs/stp202502_0006) for the PR checklist for guidance as well as other general PR information._

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,3 +1,6 @@
+# NOTE: Change / update the BRANCH variable in the repository settings to test against specific branches
+# (Or indicate in the PR for someone to do that for you)
+
 name: CI Pipeline
 
 on:
@@ -10,7 +13,7 @@ jobs:
 
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up Python
       uses: actions/setup-python@v4
@@ -20,17 +23,34 @@ jobs:
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install pytest toml
-   
-    - name: Install Package
-      run: |
-        pip install .
 
-    - name: Run Tests and Save Results
-      id: pytest_results
-      run: |
-        pytest tests/ --tb=short --maxfail=1 --junitxml=report.xml | tee pytest_output.txt
+    - name: Checkout ETC Package
+      uses: actions/checkout@v4
+    - name: Checkout ETC WCC
+      run: | 
+        git clone --branch "${{ vars.BRANCH }}" https://github.com/uasal/stp_etc_imaging.git
 
-        PASSED=$(python -c "import re; f=open('pytest_output.txt').read(); match=re.search(r'(\d+) passed', f); print(match.group(1) if match else '0')")
-        FAILED=$(grep -oP '\d+(?= failed)' pytest_output.txt || echo "0")
+    - name: Install Packages
+      run: |
+        cd stp_etc_imaging
+        pip install .[dev]
+        cd ..
+        pip install .[dev]
+
+    - name: Run PyTests- Config Package
+      id: config_pytest_results
+      run: |
+        cd tests
+        pytest --tb=short --maxfail=1 --junitxml=report.xml | tee config_pytest_output.txt
+
+        PASSED=$(python -c "import re; f=open('config_pytest_output.txt').read(); match=re.search(r'(\d+) passed', f); print(match.group(1) if match else '0')")
+        FAILED=$(grep -oP '\d+(?= failed)' config_pytest_output.txt || echo "0")
+
+    - name: Run PyTests- ETC Package Custom Branch
+      id: etc_pytest_results
+      run: |
+        cd stp_etc_imaging/tests
+        pytest --tb=short --maxfail=1 --junitxml=report.xml | tee etc_pytest_output.txt
+
+        PASSED=$(python -c "import re; f=open('etc_pytest_output.txt').read(); match=re.search(r'(\d+) passed', f); print(match.group(1) if match else '0')")
+        FAILED=$(grep -oP '\d+(?= failed)' etc_pytest_output.txt || echo "0")

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,12 +24,15 @@ jobs:
       run: |
         python -m pip install --upgrade pip
 
+      # Checkout / clone stp_etc_imaging (custom branch)  
     - name: Checkout ETC Package
       uses: actions/checkout@v4
     - name: Checkout ETC WCC
       run: | 
         git clone --branch "${{ vars.BRANCH }}" https://github.com/uasal/stp_etc_imaging.git
 
+      # Install the custom branch stp_etc_imaging package  
+      # Re-installs the config repo to be the one checkout
     - name: Install Packages
       run: |
         cd stp_etc_imaging
@@ -37,6 +40,7 @@ jobs:
         cd ..
         pip install .[dev]
 
+      # Pytest Run for the configuration package
     - name: Run PyTests- Config Package
       id: config_pytest_results
       run: |
@@ -46,8 +50,8 @@ jobs:
         PASSED=$(python -c "import re; f=open('config_pytest_output.txt').read(); match=re.search(r'(\d+) passed', f); print(match.group(1) if match else '0')")
         FAILED=$(grep -oP '\d+(?= failed)' config_pytest_output.txt || echo "0")
 
-      # 
-    - name: Run PyTests- ETC Package Custom Branch
+      # Pytest from stp_etc_imaging Package (custom branch)
+    - name: Run PyTests- stp_etc_imaging branch
       id: etc_pytest_results
       run: |
         cd stp_etc_imaging/tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,12 +1,12 @@
 # NOTE: Change / update the BRANCH variable in the repository settings to test against specific branches
 # (Or indicate in the PR for someone to do that for you)
 
-name: CI Pipeline
+name: Package Install & PyTest Checks
 
 on:
-  push:
-    branches:
-      - '**'
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
 jobs:
   check-tomls-python3-12:
     runs-on: ubuntu-latest
@@ -46,6 +46,7 @@ jobs:
         PASSED=$(python -c "import re; f=open('config_pytest_output.txt').read(); match=re.search(r'(\d+) passed', f); print(match.group(1) if match else '0')")
         FAILED=$(grep -oP '\d+(?= failed)' config_pytest_output.txt || echo "0")
 
+      # 
     - name: Run PyTests- ETC Package Custom Branch
       id: etc_pytest_results
       run: |

--- a/README.md
+++ b/README.md
@@ -1,38 +1,82 @@
-# config_project_template
-Example of a configuration repository that is used with a specific simulation tool (or group of tools).
+# config_um_wcc
 
-The naming convention should be config_project_toolname. So a hypothetical example could be `config_hubble_acs`.
+UM WCC-specific repository for support data and configuration management as an installable python package. 
 
-The directory structure is designed as follows:
+Details on the Configuration Management Plan for these repos can be found in the [UASAL Development Guide](https://uasal.github.io/uasal_development_guide/python/configuration_management.html).
 
-- Configuration parameters that are common to all tools in the repository belong in the `common_params.toml` file. 
-- A separate directory (should be named the same as the repo) is needed for python packaging (`config_project_template`).
-- All tool configs must have an `_init.toml` file which contains the default set of parameters for that tool.
-- Config files must contain both values and units. 
-  - Units shall utilize the astropy format.
-- Values without a unit will be marked as *unitless*.
-- The origin of the values should be in a comment (for now).
-- At this time, no other filenames should start with an `_`. This functionality is reserved for future feature implementation(s).
-- Any added configuration file must contain the *full set* of available parameters and not just overrides for the defaults.
+The parameters for each subsystem are found in the `configs` directory, and supporting data is found in the `support_data` directory.
+A description of how configurations are used in UASAL software, users can find an example notebook in the `docs` directory of the  [config_project_template](https://github.com/uasal/config_project_template) repository. 
 
-Configuration files may contain key valued pairs, but also utilize groupings. Such as:
+## Dependencies and Requirements
 
-```toml
-OD_optic1 = '50e-3m'
-[sim_settings]  # settings for simulation tool
-npix = 4096 # number of pixels per frame
-beamrad = 0.4 # fractional beam radius
+`config_um_wcc` is dependent on [utils_config](https://github.com/uasal/utils_config) but will automatically be installed via 
+```sh 
+pip install git+https://github.com/uasal/config_um_wcc.git
 ```
 
-## Configuration Management
-Refer to the [UASAL Configuration Management Summary](https://github.com/uasal/lab_documents/blob/main/computing/development_guide/configuration_management.md) for additionally details on how analysis, simulation tools, and configuration repositories are structured within the UASAL GitHub organization.
+## Pip Installation
 
-For Configuration FAQ's, also defer to the [UASAL Configuration Management Summary](https://github.com/uasal/lab_documents/blob/main/computing/development_guide/configuration_management.md) for more information.
+```sh
+pip install git+https://github.com/uasal/config_um_wcc.git
+```
 
-------------
+## Git Clone Installation
 
-<!-- This code uses ``pre-commit`` to check yaml file syntax, maintain ``black`` formatting, and check ``flake8`` compliance.
-To enable this, run the following commands once (the first removes the previous pre-commit hook)::
+### **1. Clone the Repository**
+```sh
+git clone https://github.com/uasal/config_um_wcc.git
+cd config_um_wcc
+```
 
-    git config --unset-all core.hooksPath
-    pre-commit install -->
+### **2. Install the Package**
+```sh
+pip install .
+```
+
+> [!Note]
+> To install package with optional dependencies *(ex. pytest)*, run the following pip command instead:<br>
+> 
+> `pip install '.[dev]'`<br>
+> **OR**<br>
+> `pip install ".[dev]"`
+>
+> Pytests will be able to be used when installing `config_um_wcc` with the `.[dev]` command.
+
+## Usage
+
+config_um_wcc makes usage of the ConfigLoader class (as *config_loader*) from utils_config via the `load_config_values` method, accepting 'raw' 'parsed' or 'unitless' as an argument, returning a dictionary after parsing the 'configs' directory for .toml files
+```python
+import config_um_wcc
+data = config_um_wcc.load_config_values()
+```
+
+load_config_values() has a default argument of 'raw' but alternatively accepts 3 arguments that trigger data to be formatted differently: 
+- `load_config_values('unitless')` -> 0.01
+- `load_config_values('parsed')` -> {'value': 0.01, 'unit': 'arcsecond'}
+- `load_config_values('raw')` -> 10e-3arcsecond
+
+For importing data and keeping code consistent across installs, config_um_wcc will return the path to support_data with `get_data_path()`
+```python
+import config_um_wcc
+data_path = config_um_wcc.get_data_path()
+print(data_path)
+``` 
+
+## Astropy Unit Validation
+
+All .toml config values should have a valid astropy unit if any units are defined. If no unit is included, the value is assumed to be unitless. A GitHub CI will automatically run a test on push to validate astropy units in the configs, reporting any issues with non-conforming astropy units. If you'd like to perform validation locally, you may run `pytest tests/test_configs.py` from the root directory of the repo. Alternatively in your python environment you may run the following snippet:
+```python
+import config_um_wcc
+config_um_wcc.load_config_values("parsed", return_loader=True).validate_astropy()
+```
+Which will return 'True' if every unit is a valid astropy unit, or a list containing every invalid unit. If you would like to use a custom u
+nit, click [here](https://docs.astropy.org/en/stable/units/combining_and_defining.html#defining-units) for how to define that as a custom unit in Astropy.
+  
+
+## Git large file storage (LFS)
+
+This repository makes use of the git large file storage for files listed in the `.gitattributes` file.
+Accessing these files will require users having (Git Large File Storage (LFS))[https://docs.github.com/en/repositories/working-with-files/managing-large-files/installing-git-large-file-storage] installed on their local machine.
+
+If you have Git LFS installed, then the large files will be pulled by default.
+This can be disabled in your gitconfig, as described (at this link)[https://stackoverflow.com/questions/42019529/how-to-clone-pull-a-git-repository-ignoring-lfs].

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,9 @@ dependencies = [
 ]
 dynamic = ["version"]
 
+[project.optional-dependencies]
+dev = ["pytest"]
+
 [project.urls]
 Homepage = "https://github.com/uasal/config_um_wcc/blob/main/README.md" 
 Changelog = "https://github.com/uasal/config_um_wcc/blob/main/CHANGELOG.md" 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-# List requirements for package here
-toml
-utils_config

--- a/tests/test_config_files.py
+++ b/tests/test_config_files.py
@@ -1,10 +1,9 @@
-import config_project_template # CHANGE this to name of your tool / repo
+import config_um_wcc
 from pathlib import Path
 
 from utils_config import ConfigLoader
 
-# CHANGE the path 'config_project_template' to your tool / repo name
-CONFIGS_PATH = Path(config_project_template.__file__).parent / "configs"
+CONFIGS_PATH = Path(config_um_wcc.__file__).parent / "configs"
 
 def test_load_configs_valid():
     """
@@ -25,5 +24,5 @@ def test_astropy_units():
     and then return either [] for no errors (passing assert), or a list containing information on each violation
     """
     # CHANGE the path 'config_project_template' to your tool / repo name
-    errors = config_project_template.load_config_values("parsed", return_loader=True).validate_astropy()
+    errors = config_um_wcc.load_config_values("parsed", return_loader=True).validate_astropy()
     assert errors == True, "Invalid astropy units found:\n" + "\n".join(errors)

--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -1,10 +1,9 @@
 import pytest
 import importlib.metadata
-import config_project_template # CHANGE this to your tool / repo name
+import config_um_wc
 
 def test_version_consistency():
     """Ensure __version__ and importlib.metadata.version report the same value."""
-    # CHANGE this to your tool / repo name
-    package_version = importlib.metadata.version("config_project_template") 
-    module_version = config_project_template.__version__
+    package_version = importlib.metadata.version("config_um_wcc") 
+    module_version = config_um_wcc.__version__
     assert module_version == package_version, f"Version mismatch: __version__={module_version}, metadata.version={package_version}. Verify package is up-to-date."

--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -1,6 +1,6 @@
 import pytest
 import importlib.metadata
-import config_um_wc
+import config_um_wcc
 
 def test_version_consistency():
     """Ensure __version__ and importlib.metadata.version report the same value."""


### PR DESCRIPTION
# Description
Updating templates and CI process for allowing to test against other branches and with the ETC package at least. Slightly manual but don't need to update the ci file physically to do this at least (change `BRANCH` variable in repo settings).

## Changes Made
- Update PR Template
  - Include branch indicator for what ETC version you want to test against
  - Want to do this a bit differently in the future but just implemented this quickly for testing purposes
- Update `ci.yaml`
  - Clones the '[stp_etc_imaging](https://github.com/uasal/stp_etc_imaging)' package for testing against and installs
    - Uses `BRANCH` variable for allowing testing against specific branches for the package
      - Probably would want to have a tag / release for this process as well in the future but again implemented this quickly  
  - Runs pytest for both config tests and tests for the `stp_etc_imaging` package testing against
  - Remove `requirement.txt` dependency step 
- Removed `requirements.txt`
  - Utilizing the dev install for ci instead (no need for both now)      
- Update `README.md`
  - Was just using the template / pulled from `https://github.com/uasal/config_stp_wcc` for a baseline and added some adjustments. 
- Fix pytests
  - Still in template form  

## Related Issues
- https://github.com/uasal/config_um_wcc/issues/5

Closes #5 

## Testing Performed
Used with testing PR: https://github.com/uasal/config_um_wcc/pull/3

> [!Note]
> Need to update the `BRANCH` variable in the repo settings for selecting what package of ETC you want to use for the testing currently. Variable _should_ be manually changed back to `develop` afterwards (for now at least).