### PR TITLE
Add focal plane size that corresponds to the optimized science area

### DIFF
--- a/src/config_um_wcc/configs/common_params.toml
+++ b/src/config_um_wcc/configs/common_params.toml
@@ -55,3 +55,7 @@ well_depth = "sensors/ZWO_ASI6200MM/ZWO_ASI6200MM_Pro_Well_Depth_vs_Gain_Setting
 temp_nominal = '20Celsius' # CBE
 temp_nominal_range = '1Kelvin' # CBE
 temp_stability = '0.1Kelvin/hour' # WAG
+
+[focal_plane]
+fov_sci_field_w = "210.0mm" # Design Optimized Science Area - derived from REQ - L3PL
+fov_sci_field_h = "120.0mm" # Design Optimized Science Area - derived from REQ - L3PL

--- a/src/config_um_wcc/configs/common_params.toml
+++ b/src/config_um_wcc/configs/common_params.toml
@@ -57,5 +57,7 @@ temp_nominal_range = '1Kelvin' # CBE
 temp_stability = '0.1Kelvin/hour' # WAG
 
 [focal_plane]
-fov_sci_field_w = "210.0mm" # Design Optimized Science Area - derived from REQ - L3PL
-fov_sci_field_h = "120.0mm" # Design Optimized Science Area - derived from REQ - L3PL
+fov_sci_field_w = "210.0mm" # Design Optimized Science Area - derived from PAY-0005, approximated to central detectors. Req from PAY.csv in v0.1 tag of UM reqs.
+fov_sci_field_h = "120.0mm" # Design Optimized Science Area - derived from PAY-0005, approximated to central detectors
+fov_full_field_w = "463.5mm" # Measured projected width of curved plane, sensor edge to sensor edge, per Steve M on 2025-09-12
+fov_full_field_h = "227.0mm" # Measured projected width of curved plane, sensor edge to sensor edge, per Steve M on 2025-09-12


### PR DESCRIPTION
Adds physical size of area of the focal plane that is optimized for science (has the best IQ). Linked to a requirement, but also used in STOP analysis code.


